### PR TITLE
Add manual workflow dispatch to GitHub Actions

### DIFF
--- a/.github/workflows/build-circleci-python-rust.yaml
+++ b/.github/workflows/build-circleci-python-rust.yaml
@@ -7,6 +7,7 @@ on:
       - '**'
   schedule:
   - cron: "30 2 * * *"
+  workflow_dispatch:
 
 jobs:
   build-circleci-python-rust:

--- a/.github/workflows/build-clickhouse-tools.yaml
+++ b/.github/workflows/build-clickhouse-tools.yaml
@@ -5,6 +5,7 @@ on:
       - master
     tags:
       - '**'
+  workflow_dispatch:
 
 jobs:
   build-push-clickhouse-tools:

--- a/.github/workflows/build-debian-slim.yaml
+++ b/.github/workflows/build-debian-slim.yaml
@@ -5,6 +5,7 @@ on:
       - master
     tags:
       - '**'
+  workflow_dispatch:
 
 jobs:
   build-push-debian-slim:

--- a/.github/workflows/build-push-web3.yaml
+++ b/.github/workflows/build-push-web3.yaml
@@ -5,6 +5,7 @@ on:
       - master
     tags:
       - '**'
+  workflow_dispatch:
 
 jobs:
   build-push-python-web3:


### PR DESCRIPTION
Enable manual triggering for all build workflows via workflow_dispatch