### PR TITLE
clickhouse-tools: install cryo_cli from git source

### DIFF
--- a/clickhouse-tools/Dockerfile
+++ b/clickhouse-tools/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install clickhouse-client and aws-cli (s3 binary)
 RUN apt-get update && \
-    apt-get install -y curl unzip gnupg2 software-properties-common build-essential && \
+    apt-get install -y curl unzip gnupg2 software-properties-common build-essential pkg-config libssl-dev && \
     curl -fsSL 'https://packages.clickhouse.com/rpm/lts/repodata/repomd.xml.key' | gpg --dearmor -o /usr/share/keyrings/clickhouse-keyring.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg] https://packages.clickhouse.com/deb stable main" | tee \
         /etc/apt/sources.list.d/clickhouse.list && \
@@ -20,4 +20,4 @@ RUN apt-get clean && \
 # Install Rust, Cargo and cryo_cli
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 RUN echo "export PATH=/root/.cargo/bin:$PATH" >> /root/.bashrc
-RUN /root/.cargo/bin/cargo install cryo_cli
+RUN /root/.cargo/bin/cargo install --git https://github.com/paradigmxyz/cryo --locked cryo_cli


### PR DESCRIPTION
- Install cryo_cli directly from GitHub repo instead of crates.io
- Add pkg-config and libssl-dev build dependencies required for compilation